### PR TITLE
First prototype implementation of computing unique hashes in repos

### DIFF
--- a/pydatatask/repository/base.py
+++ b/pydatatask/repository/base.py
@@ -94,15 +94,6 @@ class Repository(ABC):
     def __aiter__(self) -> AsyncIterator[str]:
         return self.filter_jobs(self.unfiltered_iter())
 
-    @abstractmethod
-    def unfiltered_iter(self) -> AsyncGenerator[str, None]:
-        """The core method of Repository.
-
-        Implement this to produce an iterable of every string which could potentially be a job identifier present in
-        this repository. When the repository is iterated directly, this will be filtered by `filter_jobs`.
-        """
-        raise NotImplementedError
-
     async def template(self, job: str, task: taskmodule.Task, kind: taskmodule.LinkKind) -> taskmodule.TemplateInfo:
         """Returns an arbitrary piece of data related to job.
 
@@ -114,6 +105,22 @@ class Repository(ABC):
         if kind in (taskmodule.LinkKind.InputRepo, taskmodule.LinkKind.OutputRepo):
             return taskmodule.TemplateInfo(self)
         raise ValueError(f"{type(self)} cannot be templated as {kind} for {task}")
+
+    @abstractmethod
+    def unfiltered_iter(self) -> AsyncGenerator[str, None]:
+        """The core method of Repository.
+
+        Implement this to produce an iterable of every string which could potentially be a job identifier present in
+        this repository. When the repository is iterated directly, this will be filtered by `filter_jobs`.
+        """
+        raise NotImplementedError
+
+    async def get_unique_hash(self, job: str) -> Optional[str]:
+        """Get the hash of the given job, if it is present in the repository.
+
+        This is used by the pipeline to determine whether a job needs to be recomputed.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     async def delete(self, job):

--- a/pydatatask/repository/bucket.py
+++ b/pydatatask/repository/bucket.py
@@ -148,6 +148,16 @@ class S3BucketRepository(S3BucketRepositoryBase, BlobRepository):
         else:
             return True
 
+    async def get_unique_hash(self, job: str) -> str | None:
+        # use the ETag as the unique hash
+        try:
+            return (await self.client.head_object(Bucket=self.bucket, Key=self.object_name(job)))["ETag"]
+        except botocore.exceptions.ClientError as e:
+            if "404" in str(e):
+                return None
+            else:
+                raise
+
     async def unfiltered_iter(self):
         paginator = self.client.get_paginator("list_objects")
         async for page in paginator.paginate(Bucket=self.bucket, Prefix=self.prefix):

--- a/pydatatask/repository/docker.py
+++ b/pydatatask/repository/docker.py
@@ -1,6 +1,6 @@
 """This module contains repositories for interacting with docker registries."""
 
-from typing import Callable
+from typing import Callable, Optional
 import base64
 import hashlib
 import os
@@ -54,6 +54,14 @@ class DockerRepository(Repository):
         except aiohttp.client_exceptions.ClientResponseError as e:
             if e.status != 404:
                 raise
+
+    async def get_unique_hash(self, job: str) -> str | None:
+        # get the digest of the image
+        image = docker_registry_client_async.imagename.ImageName(
+            self.repository, tag=job, endpoint=self.domain
+        )
+        # don't know exactly how this works yet
+        return image.digest
 
     def __repr__(self):
         return f"<dockerRepository {self.domain}/{self.repository}:*>"

--- a/pydatatask/repository/kubernetes.py
+++ b/pydatatask/repository/kubernetes.py
@@ -28,6 +28,14 @@ class LiveKubeRepository(Repository):
     async def contains(self, item):
         return bool(await self.task.podman.query(task=self.task.name, job=item))
 
+    async def get_unique_hash(self, job: str) -> str | None:
+        # get the digest of the image
+        pods = await self.task.podman.query(job=job, task=self.task.name)
+        if not pods:
+            return None
+        pod = pods[0]
+        return pod.metadata.labels["unique_hash"]
+
     def __repr__(self):
         return f"<LiveKubeRepository task={self.task.name}>"
 

--- a/pydatatask/repository/mongodb.py
+++ b/pydatatask/repository/mongodb.py
@@ -36,6 +36,13 @@ class MongoMetadataRepository(MetadataRepository):
     async def contains(self, item):
         return await self.collection.count_documents({"_id": item}) != 0
 
+    async def get_unique_hash(self, job: str) -> str | None:
+        # get the digest of the image
+        result = await self.collection.find_one({"_id": job}, projection=["unique_hash"])
+        if result is None:
+            return None
+        return result["unique_hash"]
+
     async def delete(self, job):
         await self.collection.delete_one({"_id": job})
 


### PR DESCRIPTION
First attempt at a prototype of potentially using unique hashes based on the different repositories.
By composing the hashes of all inputs to a pipeline step, we can implement an idempotent id of the inputs (e.g. for ALLOC to create deterministic keys).

IMPORTANT: this is a simple prototype implementation that I just typed out/Copilot'ed without testing. this probably doesn't work. It's just here to get feedback.