### PR TITLE
Add logging when there is not enough quota to launch a task

### DIFF
--- a/pydatatask/cli/lock.py
+++ b/pydatatask/cli/lock.py
@@ -199,6 +199,7 @@ def parse_host(thing: str):
         }[os.lower()],
     )
 
+
 def parse_volumespec_dict(thing: str):
     things = thing.split("::")
     result = {}
@@ -240,7 +241,6 @@ def subargparse(**outer_kwargs) -> Callable[[Callable[..., T]], Callable[[str], 
     return outer
 
 
-
 @subargparse(quota=parse_quota)
 def local_exec_allocator(quota=None):
     LOCK_PATH.mkdir(exist_ok=True, parents=True)
@@ -259,8 +259,17 @@ def local_exec_allocator(quota=None):
     return inner
 
 
-@subargparse(local_quota=parse_quota, kube_quota=parse_quota, namespace=str, kube_host=parse_host, kube_context=str, kube_volumes=parse_volumespec_dict)
-def local_exec_kube_allocator(local_quota=None, kube_quota=None, namespace=None, kube_host=None, kube_context=None, kube_volumes=None):
+@subargparse(
+    local_quota=parse_quota,
+    kube_quota=parse_quota,
+    namespace=str,
+    kube_host=parse_host,
+    kube_context=str,
+    kube_volumes=parse_volumespec_dict,
+)
+def local_exec_kube_allocator(
+    local_quota=None, kube_quota=None, namespace=None, kube_host=None, kube_context=None, kube_volumes=None
+):
     LOCK_PATH.mkdir(exist_ok=True, parents=True)
     dargs = {
         "nil_ephemeral": "nil_ephemeral",
@@ -512,9 +521,7 @@ def main():
     locked.spec.global_template_env.update(
         {k: v for k, v in [line.split("=", 1) for line in parsed.global_template_env]}
     )
-    locked.spec.global_script_env.update(
-        {k: v for k, v in [line.split("=", 1) for line in parsed.global_script_env]}
-    )
+    locked.spec.global_script_env.update({k: v for k, v in [line.split("=", 1) for line in parsed.global_script_env]})
     locked.spec.ephemerals.update(dict(EPHEMERALS.values()))
     locked.spec.ephemerals["nil_ephemeral"] = Dispatcher("Nil", {})
     locked.save()

--- a/pydatatask/declarative.py
+++ b/pydatatask/declarative.py
@@ -306,11 +306,15 @@ def make_annotated_constructor(
     return make_constructor(name, inner_constructor, schema)
 
 
-volumespec_constructor = make_constructor("VolumeSpec", VolumeSpec, {
-    "pvc": lambda thing: thing if thing is None else str(thing),
-    "host_path": lambda thing: thing if thing is None else str(thing),
-    "null": parse_bool,
-})
+volumespec_constructor = make_constructor(
+    "VolumeSpec",
+    VolumeSpec,
+    {
+        "pvc": lambda thing: thing if thing is None else str(thing),
+        "host_path": lambda thing: thing if thing is None else str(thing),
+        "null": parse_bool,
+    },
+)
 
 
 def build_repository_picker(ephemerals: Mapping[str, Callable[[], Any]]) -> Callable[[Any], Repository]:
@@ -674,12 +678,15 @@ def build_task_picker(
         },
     )
     queries_constructor = make_dict_parser("queries", str, query_constructor)
+
     def mk_container_wrapper(initial):
         def container_wrapper(thing):
-            if 'host_mounts' in thing:
-                thing['mounts'] = thing.pop('host_mounts')
+            if "host_mounts" in thing:
+                thing["mounts"] = thing.pop("host_mounts")
             return initial(thing)
+
         return container_wrapper
+
     kinds = {
         "Process": make_annotated_constructor(
             "ProcessTask",
@@ -737,11 +744,12 @@ def build_task_picker(
                 # fmt: on
             },
         ),
-        "Container": mk_container_wrapper(make_annotated_constructor(
-            "ContainerTask",
-            ContainerTask,
-            {
-                # fmt: off
+        "Container": mk_container_wrapper(
+            make_annotated_constructor(
+                "ContainerTask",
+                ContainerTask,
+                {
+                    # fmt: off
                 # Common to all tasks
                 "name": str,
                 "executor": make_picker("Executor", executors),
@@ -765,9 +773,10 @@ def build_task_picker(
                 "privileged": parse_bool,
                 "tty": parse_bool,
                 "mounts": make_dict_parser("mounts", str, str),
-                # fmt: on
-            },
-        )),
+                    # fmt: on
+                },
+            )
+        ),
     }
     for ep in entry_points(group="pydatatask.task_constructors"):
         maker = ep.load()

--- a/pydatatask/executor/pod_manager.py
+++ b/pydatatask/executor/pod_manager.py
@@ -4,7 +4,6 @@ needs several resource references.
 the `PodManager` simplifies tracking the lifetimes of these resources.
 """
 
-from dataclasses import dataclass
 from typing import (
     Any,
     AsyncIterator,
@@ -16,10 +15,10 @@ from typing import (
     Tuple,
 )
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import asyncio
 import logging
-from typing_extensions import Self
 
 from kubernetes_asyncio.client import ApiClient, ApiException, CoreV1Api
 from kubernetes_asyncio.config import (
@@ -29,6 +28,7 @@ from kubernetes_asyncio.config import (
 )
 from kubernetes_asyncio.config.kube_config import Configuration
 from kubernetes_asyncio.stream import WsApiClient
+from typing_extensions import Self
 
 from pydatatask.executor import Executor
 from pydatatask.executor.container_manager import KubeContainerManager
@@ -96,7 +96,7 @@ class VolumeSpec:
 
     @classmethod
     def parse(cls, data: str) -> Self:
-        if '/' in data:
+        if "/" in data:
             return cls(host_path=data)
         return cls(pvc=data)
 

--- a/pydatatask/pipeline.py
+++ b/pydatatask/pipeline.py
@@ -327,6 +327,7 @@ class Pipeline:
                 alloc = self.tasks[task].job_quota
                 excess = (used + alloc).excess(quota)
                 if excess is not None:
+                    l.warning("Not enough quota %s to allocate task %s:%s which required %s already used %s", quota, task, job, alloc, used)
                     break
                 used += alloc
                 await queue.put((task, job, 0, False))

--- a/pydatatask/pipeline.py
+++ b/pydatatask/pipeline.py
@@ -327,7 +327,14 @@ class Pipeline:
                 alloc = self.tasks[task].job_quota
                 excess = (used + alloc).excess(quota)
                 if excess is not None:
-                    l.warning("Not enough quota %s to allocate task %s:%s which required %s already used %s", quota, task, job, alloc, used)
+                    l.warning(
+                        "Not enough quota %s to allocate task %s:%s which required %s already used %s",
+                        quota,
+                        task,
+                        job,
+                        alloc,
+                        used,
+                    )
                     break
                 used += alloc
                 await queue.put((task, job, 0, False))


### PR DESCRIPTION
When there's not enough quota to launch a task, pdt fails silently. 

This PR adds a warning message when we cannot allocate a task.