### PR TITLE
Add disable-quota flag that will remove quotas for testing and development

### DIFF
--- a/pydatatask/main.py
+++ b/pydatatask/main.py
@@ -112,6 +112,8 @@ def main(
         "--fail-fast", action="store_true", help="Do not catch exceptions thrown during routine operations"
     )
     parser_run.add_argument(
+        "--disable-quota", action="store_true", help="Prevent local quota from ever preventing a task from running")
+    parser_run.add_argument(
         "--require-success",
         action="store_true",
         help="Raise an error when workers fail instead of marking them as completed-but-failed",
@@ -435,11 +437,12 @@ async def run(
     once: bool = False,
     global_template_env: Optional[List[str]] = None,
     global_script_env: Optional[List[str]] = None,
+    disable_quota: bool = False,
 ):
     if tasks == []:
         tasks = None
     pipeline.settings(
-        fail_fast=fail_fast, task_allowlist=tasks, debug_trace=debug_trace, require_success=require_success
+        fail_fast=fail_fast, task_allowlist=tasks, debug_trace=debug_trace, require_success=require_success, disable_quota=disable_quota
     )
     pipeline.global_template_env.update(dict([line.split("=", 1) for line in global_template_env or []]))
     pipeline.global_script_env.update(dict([line.split("=", 1) for line in global_script_env or []]))

--- a/pydatatask/main.py
+++ b/pydatatask/main.py
@@ -112,7 +112,8 @@ def main(
         "--fail-fast", action="store_true", help="Do not catch exceptions thrown during routine operations"
     )
     parser_run.add_argument(
-        "--disable-quota", action="store_true", help="Prevent local quota from ever preventing a task from running")
+        "--disable-quota", action="store_true", help="Prevent local quota from ever preventing a task from running"
+    )
     parser_run.add_argument(
         "--require-success",
         action="store_true",
@@ -442,7 +443,11 @@ async def run(
     if tasks == []:
         tasks = None
     pipeline.settings(
-        fail_fast=fail_fast, task_allowlist=tasks, debug_trace=debug_trace, require_success=require_success, disable_quota=disable_quota
+        fail_fast=fail_fast,
+        task_allowlist=tasks,
+        debug_trace=debug_trace,
+        require_success=require_success,
+        disable_quota=disable_quota,
     )
     pipeline.global_template_env.update(dict([line.split("=", 1) for line in global_template_env or []]))
     pipeline.global_script_env.update(dict([line.split("=", 1) for line in global_script_env or []]))

--- a/pydatatask/pipeline.py
+++ b/pydatatask/pipeline.py
@@ -117,6 +117,7 @@ class Pipeline:
         self.agent_hosts: Dict[Optional[Host], str] = agent_hosts or {None: "localhost"}
         self.source_file = source_file
         self.fail_fast = False
+        self.disable_quota = False
         self.long_running_timeout = long_running_timeout
         self.global_template_env = global_template_env or {}
         self.global_script_env = global_script_env or {}


### PR DESCRIPTION
Adds `--disable-quota` to `pd` so that we can run pipelines in testing and development that do not enforce a quota. 